### PR TITLE
Explore items change

### DIFF
--- a/src/components/explore/ExploreItems.jsx
+++ b/src/components/explore/ExploreItems.jsx
@@ -10,6 +10,7 @@ const ExploreItems = () => {
   const [exploreItems, setExploreItems] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [numLoaded, setNumLoaded] = useState(8);
+  const [allLoaded, setAllLoaded] = useState(false);
 
   async function fetchData(apiURL) {
     const { data } = await axios.get(apiURL || API);
@@ -32,8 +33,11 @@ const ExploreItems = () => {
   }
 
   const displayMore = () => {
-    if (numLoaded + 4 <= exploreItems.length) {
-      setNumLoaded(numLoaded + 4);
+    let loaded = numLoaded
+    if (loaded + 4 <= exploreItems.length) {
+      loaded += 4
+      setNumLoaded(loaded);
+      loaded >= 16 && setAllLoaded(true);
     }
   };
 
@@ -162,9 +166,11 @@ const ExploreItems = () => {
             </div>
           ))}
       <div className="col-md-12 text-center">
-        <button id="loadmore" className="btn-main lead" onClick={displayMore}>
-          Load more
-        </button>
+        {!allLoaded && (
+          <button id="loadmore" className="btn-main lead" onClick={displayMore}>
+            Load more
+          </button>
+        )}
       </div>
     </>
   );


### PR DESCRIPTION
made it so load button no longer shows when there is no more nfts to load in (better user experience as they wont be trying to load more when theres no more to load)

before
![image](https://github.com/yuhuicaoo/yuhui-internship/assets/130331257/4ab40df9-92f0-4b6c-80cd-7b6ef00148d4)

after
![image](https://github.com/yuhuicaoo/yuhui-internship/assets/130331257/2d1552ec-8afe-4ea1-bee7-d1d2ded32c25)
